### PR TITLE
Make username and password optional

### DIFF
--- a/api/node-proxy.js
+++ b/api/node-proxy.js
@@ -10,15 +10,15 @@ const server = http.createServer(function(req, res) {
 
   // load from ENVs
   const origin = process.env.ORIGIN;
-  const password = process.env.PASSWORD;
-  const username = process.env.USERNAME;
+  const password = process.env.PASSWORD || null;
+  const username = process.env.USERNAME || null;
 
-  
+  const credentialsConfigured = username && password;
   
   // console.log('ORIGIN:', process.env.ORIGIN);
   
   const credentials = auth(req);
-  if (!credentials || !isAuthed(credentials, username, password)) {
+  if (credentialsConfigured && (!credentials || !isAuthed(credentials, username, password))) {
     res.statusCode = 401;
     res.setHeader('WWW-Authenticate', 'Basic realm="example"');
     res.end('Access denied.');


### PR DESCRIPTION
I had a use case where I needed to quickly remove the basic auth requirements but noticed there is no easy way to do so.

This defaults to just proxying the origin server if you don't set `USERNAME` and `PASSWORD`.

PS. I understand that conceptually you might not want to merge this, since unconfigured environments would become open.